### PR TITLE
Catch error on StringReverse function missing, fixes #54

### DIFF
--- a/lib/mulelogin.au3
+++ b/lib/mulelogin.au3
@@ -52,6 +52,9 @@ Func _length($string)
         $declength = Floor($declength/2)
     WEnd
 	$binlength = StringReverse($binlength)
+	if @error <> 0 Then
+		$binlength = _StringReverse($binlength)
+	EndIf
 	$binlength = $binlength & "1"
 	$array = StringSplit($binlength,"")
 	For $i = 1 To $array[0]


### PR DESCRIPTION
For reference: #54 

Effectively changed the previous

```
$binlength = StringReverse($binlength)
```

to

```
try {
    $binlength = StringReverse($binlength)
} catch {
    $binlength = _StringReverse($binlength)
}
```
