### PR TITLE
Fixed one-click login, fixes atomizer/muledump#68

### DIFF
--- a/lib/mulelogin.au3
+++ b/lib/mulelogin.au3
@@ -104,7 +104,7 @@ _build()
 
 $path = @AppDataDir & "\Macromedia\Flash Player\#SharedObjects\"
 $search = FileFindFirstFile($path & "*")
-$path &= FileFindNextFile($search) & "\www.realmofthemadgod.com\RotMG.sol"
+$path &= FileFindNextFile($search) & "\realmofthemadgodhrd.appspot.com\RotMG.sol"
 FileClose($search)
 $file = FileOpen($path,18)
 FileWrite($file,$string)
@@ -114,3 +114,5 @@ ShellExecute("http://www.realmofthemadgod.com/")
 ; replace the line above if you're using a projector
 ; for example, with totalcmd + swfview
 ;ShellExecute('C:\Program Files\Total Commander\Totalcmd.exe', '/S=L:Pswfview e:\temp\rotmg\loader.swf')
+; or to open the latest swf with the default Adobe Flash Projector
+;ShellExecute('C:\flashplayer_16_sa.exe', 'https://realmofthemadgodhrd.appspot.com/AssembleeGameClient'&BinaryToString(InetRead("http://www.realmofthemadgod.com/version.txt"))&'.swf')

--- a/lib/mulelogin.au3
+++ b/lib/mulelogin.au3
@@ -102,17 +102,21 @@ $password = $data[2]
 
 _build()
 
+Local $paths[2] = ["www.realmofthemadgod.com", "realmofthemadgodhrd.appspot.com"]
 $path = @AppDataDir & "\Macromedia\Flash Player\#SharedObjects\"
 $search = FileFindFirstFile($path & "*")
-$path &= FileFindNextFile($search) & "\realmofthemadgodhrd.appspot.com\RotMG.sol"
+$searchPath = FileFindNextFile($search)
+For $gameDir In $paths
+	$gameFilePath = $path & $searchPath & "\" & $gameDir & "\RotMG.sol"
+	$file = FileOpen($gameFilePath,18)
+	FileWrite($file,$string)
+	FileClose($file)
+Next
 FileClose($search)
-$file = FileOpen($path,18)
-FileWrite($file,$string)
-FileClose($file)
 
 ShellExecute("http://www.realmofthemadgod.com/")
 ; replace the line above if you're using a projector
 ; for example, with totalcmd + swfview
 ;ShellExecute('C:\Program Files\Total Commander\Totalcmd.exe', '/S=L:Pswfview e:\temp\rotmg\loader.swf')
-; or to open the latest swf with the default Adobe Flash Projector
+; or to open the latest swf with the Adobe Flash Projector
 ;ShellExecute('C:\flashplayer_16_sa.exe', 'https://realmofthemadgodhrd.appspot.com/AssembleeGameClient'&BinaryToString(InetRead("http://www.realmofthemadgod.com/version.txt"))&'.swf')


### PR DESCRIPTION
The local flash store for your .sol is stored within a different directory, matching the new domain.
(realmofthemadgod.com -> realmofthemadgodhrd.appspot.com)

Also adds a new example for passing the full SWF location to a normal Flash projector.