### PR TITLE
One-click SOL paths improvement

### DIFF
--- a/lib/mulelogin.au3
+++ b/lib/mulelogin.au3
@@ -102,19 +102,24 @@ $password = $data[2]
 
 _build()
 
+Local $paths_base[2] = [ _
+	@AppDataDir & "\Macromedia\Flash Player\#SharedObjects\", _
+	_PathFull("../Local", @AppDataDir) & "\Google\Chrome\User Data\Default\Pepper Data\Shockwave Flash\WritableRoot\#SharedObjects\" _
+]
 Local $paths[3] = [ _
 	"localhost", _
 	"realmofthemadgodhrd.appspot.com", _
 	"www.realmofthemadgod.com" _
 ]
-$path = @AppDataDir & "\Macromedia\Flash Player\#SharedObjects\"
-$search = FileFindFirstFile($path & "*")
-$searchPath = FileFindNextFile($search)
-For $gameDir In $paths
-	$gameFilePath = $path & $searchPath & "\" & $gameDir & "\RotMG.sol"
-	$file = FileOpen($gameFilePath,26)
-	FileWrite($file,$string)
-	FileClose($file)
+For $path_base In $paths_base
+	$search = FileFindFirstFile($path_base & "*")
+	$searchPath = FileFindNextFile($search)
+	For $gameDir In $paths
+		$gameFilePath = $path_base & $searchPath & "\" & $gameDir & "\RotMG.sol"
+		$file = FileOpen($gameFilePath,26)
+		FileWrite($file,$string)
+		FileClose($file)
+	Next
 Next
 FileClose($search)
 

--- a/lib/mulelogin.au3
+++ b/lib/mulelogin.au3
@@ -102,7 +102,11 @@ $password = $data[2]
 
 _build()
 
-Local $paths[2] = ["www.realmofthemadgod.com", "realmofthemadgodhrd.appspot.com"]
+Local $paths[3] = [ _
+	"localhost", _
+	"realmofthemadgodhrd.appspot.com", _
+	"www.realmofthemadgod.com" _
+]
 $path = @AppDataDir & "\Macromedia\Flash Player\#SharedObjects\"
 $search = FileFindFirstFile($path & "*")
 $searchPath = FileFindNextFile($search)

--- a/lib/mulelogin.au3
+++ b/lib/mulelogin.au3
@@ -108,7 +108,7 @@ $search = FileFindFirstFile($path & "*")
 $searchPath = FileFindNextFile($search)
 For $gameDir In $paths
 	$gameFilePath = $path & $searchPath & "\" & $gameDir & "\RotMG.sol"
-	$file = FileOpen($gameFilePath,18)
+	$file = FileOpen($gameFilePath,26)
 	FileWrite($file,$string)
 	FileClose($file)
 Next


### PR DESCRIPTION
Creates directories if they're missing. (this assures that even on machines that haven't run RotMG, or frequently clear Flash cache, the first click will open the selected account) This does, however, assume that the directory will always be the correct one; I don't think this is a dangerous assumption.
Adds localhost to list of SOL paths.

This will keep issues such as #71 from happening in the future.