### PR TITLE
Consumable named sorting

### DIFF
--- a/lib/totals.js
+++ b/lib/totals.js
@@ -338,6 +338,7 @@ function consumable_tier(id) {
 				return 18;
 			} else { // unknown item, abandon ship! (leave its tier at -1)
 				console.log("Unknown item: " + id + " " + items[id][0]);
+				return -1;
 			}
 		// end switch
 	}

--- a/lib/totals.js
+++ b/lib/totals.js
@@ -14,13 +14,13 @@ var items = window.items
 
 function init_totals() {
 	for (var id in items) {
-		if (id == 0x151f || id == 0x153f || id == 0x1547) {
-			// Valentine, Beach Ball, and Beer Slurp Generators
+		var itemname = items[id][0];
+		if (itemname == 'Valentine Generator' || itemname == 'Beach Ball Generator' || itemname == 'Beer Slurp Generator') {
 			// special generators (added to pets)
 			items[id][1] = 26;
 		} else if (items[id][1] == 10) {
 			// set item tier for consumable sorting
-			items[id][2] = consumable_tier(id);
+			items[id][2] = consumable_tier(id, itemname);
 		}
 		ids.push(id);
 	}
@@ -151,7 +151,7 @@ function update_filter() {
 	});
 }
 
-function consumable_tier(id) {
+function consumable_tier(id, itemname) {
 	/*
 	0: Vanity HP/MP
 	1: HP/MP
@@ -173,155 +173,153 @@ function consumable_tier(id) {
 	17: Dyes
 	18: Cloths
 	*/
-	intid = parseInt(id);
-	switch (intid) {
-		case 0xab0: // Minor Health Potion
-		case 0xadd: // Minor Magic Potion
-		case 0xaeb: // Greater Health Potion
-		case 0xaec: // Greater Magic Potion
-		case 0x224b:  // Potion of Health1
-		case 0x225e:  // Potion of Health2
-		case 0x225b:  // Potion of Health3
-		case 0x224c:  // Potion of Health4
-		case 0x223c:  // Potion of Health5
-		case 0x223d:  // Potion of Health6
+	switch (itemname) {
+		case 'Minor Health Potion':
+		case 'Minor Magic Potion':
+		case 'Greater Health Potion':
+		case 'Greater Magic Potion':
+		case 'Potion of Health1':
+		case 'Potion of Health2':
+		case 'Potion of Health3':
+		case 'Potion of Health4':
+		case 'Potion of Health5':
+		case 'Potion of Health6':
 			return 0;
-		case 0xa22: // Health Potion
-		case 0xa23: // Magic Potion
+		case 'Health Potion':
+		case 'Magic Potion':
 			return 1;
-		case 0xa1f: // Potion of Attack
-		case 0xa20: // Potion of Defense
-		case 0xa21: // Potion of Speed
-		case 0xa34: // Potion of Vitality
-		case 0xa35: // Potion of Wisdom
-		case 0xa4c: // Potion of Dexterity
-		case 0xae9: // Potion of Life
-		case 0xaea: // Potion of Mana
+		case 'Potion of Attack':
+		case 'Potion of Defense':
+		case 'Potion of Speed':
+		case 'Potion of Vitality':
+		case 'Potion of Wisdom':
+		case 'Potion of Dexterity':
+		case 'Potion of Life':
+		case 'Potion of Mana':
 			return 2;
-		case 0xb34: // Fire Water
-		case 0xb35: // Cream Spirit
-		case 0xb36: // Chardonnay
-		case 0xb37: // Melon Liquer
-		case 0xb38: // Cabernet
-		case 0xb39: // Vintage Port
-		case 0xb3a: // Sauvignon Blanc
-		case 0xb3b: // Muscat
-		case 0xb3c: // Rice Wine
-		case 0xb3d: // Shiraz
+		case 'Fire Water':
+		case 'Cream Spirit':
+		case 'Chardonnay':
+		case 'Melon Liquer':
+		case 'Cabernet':
+		case 'Vintage Port':
+		case 'Sauvignon Blanc':
+		case 'Muscat':
+		case 'Rice Wine':
+		case 'Shiraz':
 			return 3;
-		case 0x2368: // Greater Potion of Attack
-		case 0x2369: // Greater Potion of Defense
-		case 0x236a: // Greater Potion of Speed
-		case 0x236b: // Greater Potion of Vitality
-		case 0x236c: // Greater Potion of Wisdom
-		case 0x236d: // Greater Potion of Dexterity
-		case 0x236e: // Greater Potion of Life
-		case 0x236f: // Greater Potion of Mana
+		case 'Greater Potion of Attack':
+		case 'Greater Potion of Defense':
+		case 'Greater Potion of Speed':
+		case 'Greater Potion of Vitality':
+		case 'Greater Potion of Wisdom':
+		case 'Greater Potion of Dexterity':
+		case 'Greater Potion of Life':
+		case 'Greater Potion of Mana':
 			return 4;
-		case 0x722: // Wine Cellar Incantation
+		case 'Wine Cellar Incantation':
 			return 5;
-		case 0xa3f: // Snake Oil
-		case 0x707: // Healing Ichor
-		case 0xa50: // Pirate Rum
-		case 0xa51: // Magic Mushroom
-		case 0xc12: // Coral Juice
-		case 0xc1a: // Pollen Powder
-		case 0xc21: // Holy Water
-		case 0xc25: // Ghost Pirate Rum
-		case 0xc80: // Speed Sprout
+		case 'Snake Oil':
+		case 'Healing Ichor':
+		case 'Pirate Rum':
+		case 'Magic Mushroom':
+		case 'Coral Juice':
+		case 'Pollen Powder':
+		case 'Holy Water':
+		case 'Ghost Pirate Rum':
+		case 'Speed Sprout':
 			return 6;
-		case 0x77b: // Tincture of Fear
-		case 0x77c: // Tincture of Courage
-		case 0xb0c: // Tincture of Dexterity
-		case 0xb0d: // Tincture of Life
-		case 0xb0e: // Tincture of Mana
-		case 0xb0f: // Tincture of Defense
-		case 0xb10: // Effusion of Dexterity
-		case 0xb11: // Effusion of Life
-		case 0xb12: // Effusion of Mana
-		case 0xb13: // Effusion of Defense
+		case 'Tincture of Fear':
+		case 'Tincture of Courage':
+		case 'Tincture of Dexterity':
+		case 'Tincture of Life':
+		case 'Tincture of Mana':
+		case 'Tincture of Defense':
+		case 'Effusion of Dexterity':
+		case 'Effusion of Life':
+		case 'Effusion of Mana':
+		case 'Effusion of Defense':
 			return 8;
-		case 0xc39: // Bahama Sunrise
-		case 0xc3a: // Blue Paradise
-		case 0xc3b: // Pink Passion Breeze
-		case 0xc3c: // Lime Jungle Bay
-		case 0xc5b: // Mad God Ale
-		case 0xc5c: // Oryx Stout
-		case 0xc5d: // Realm-wheat Hefeweizen
-		case 0xc60: // Rock Candy
-		case 0xc63: // Red Gumball
-		case 0xc64: // Purple Gumball
-		case 0xc65: // Blue Gumball
-		case 0xc66: // Green Gumball
-		case 0xc67: // Yellow Gumball
-		case 0x2375: // Candy Corn
+		case 'Bahama Sunrise':
+		case 'Blue Paradise':
+		case 'Pink Passion Breeze':
+		case 'Lime Jungle Bay':
+		case 'Mad God Ale':
+		case 'Oryx Stout':
+		case 'Realm-wheat Hefeweizen':
+		case 'Rock Candy':
+		case 'Red Gumball':
+		case 'Purple Gumball':
+		case 'Blue Gumball':
+		case 'Green Gumball':
+		case 'Yellow Gumball':
+		case 'Candy Corn':
 			return 9;
-		case 0xb14: // Elixir of Health 7
-		case 0xb15: // Elixir of Health 6
-		case 0xb16: // Elixir of Health 5
-		case 0xb17: // Elixir of Health 4
-		case 0xa81: // Elixir of Health 3
-		case 0xa48: // Elixir of Health 2
-		case 0xa49: // Elixir of Health 1
-		case 0xb18: // Elixir of Magic 7
-		case 0xb19: // Elixir of Magic 6
-		case 0xb1a: // Elixir of Magic 5
-		case 0xb1b: // Elixir of Magic 4
-		case 0xa4a: // Elixir of Magic 3
-		case 0xaed: // Elixir of Magic 2
-		case 0xaee: // Elixir of Magic 1
+		case 'Elixir of Health 7':
+		case 'Elixir of Health 6':
+		case 'Elixir of Health 5':
+		case 'Elixir of Health 4':
+		case 'Elixir of Health 3':
+		case 'Elixir of Health 2':
+		case 'Elixir of Health 1':
+		case 'Elixir of Magic 7':
+		case 'Elixir of Magic 6':
+		case 'Elixir of Magic 5':
+		case 'Elixir of Magic 4':
+		case 'Elixir of Magic 3':
+		case 'Elixir of Magic 2':
+		case 'Elixir of Magic 1':
 			return 10;
-		case 0xc2b: // Small Firecracker
-		case 0xc2c: // Large Firecracker
-		case 0xc34: // Sand Pail 5
-		case 0xc35: // Sand Pail 4
-		case 0xc36: // Sand Pail 3
-		case 0xc37: // Sand Pail 2
-		case 0xc38: // Sand Pail 1
-		case 0xc41: // Transformation Potion
-		case 0xc42: // XP Booster
-		case 0xc43: // XP Booster Test
-		case 0xc68: // Loot Tier Potion
-		case 0xc69: // Loot Drop Potion
-		case 0xc6a: // XP Booster 1 hr
-		case 0xc6b: // XP Booster 20 min
-		case 0xc6c: // Backpack
-		case 0xc81: // Old Firecracker
-		case 0xcc1: // Draconis Potion
-		case 0xcc2: // Lucky Clover
-		case 0xcc3: // Saint Patty's Brew
+		case 'Small Firecracker':
+		case 'Large Firecracker':
+		case 'Sand Pail 5':
+		case 'Sand Pail 4':
+		case 'Sand Pail 3':
+		case 'Sand Pail 2':
+		case 'Sand Pail 1':
+		case 'Transformation Potion':
+		case 'XP Booster':
+		case 'XP Booster Test':
+		case 'Loot Tier Potion':
+		case 'Loot Drop Potion':
+		case 'XP Booster 1 hr':
+		case 'XP Booster 20 min':
+		case 'Backpack':
+		case 'Old Firecracker':
+		case 'Draconis Potion':
+		case 'Lucky Clover':
+		case 'Saint Patty\'s Brew':
 			return 11;
-		case 0xcc9: // Soft Drink
-		case 0xccb: // Fries
-		case 0xcc6: // Great Taco
-		case 0xcc5: // Power Pizza
-		case 0xcc4: // Chocolate Cream Sandwich Cookie
-		case 0xcca: // Grapes of Wrath
-		case 0xcc8: // Superburger
-		case 0xcc7: // Double Cheeseburger Deluxe
-		case 0xccc: // Ambrosia
+		case 'Soft Drink':
+		case 'Fries':
+		case 'Great Taco':
+		case 'Power Pizza':
+		case 'Chocolate Cream Sandwich Cookie':
+		case 'Grapes of Wrath':
+		case 'Superburger':
+		case 'Double Cheeseburger Deluxe':
+		case 'Ambrosia':
 			return 12;
-		case 0x5e2d: // Treasure Map
+		case 'Treasure Map':
 			return 13;
-		case 0xc70: // Golden Ankh
-		case 0xc71: // Eye of Osiris
-		case 0xc72: // Pharaoh's Mask
-		case 0xc73: // Golden Cockle
-		case 0xc74: // Golden Conch
-		case 0xc75: // Golden Horn Conch
-		case 0xc76: // Golden Nut
-		case 0xc77: // Golden Bolt
-		case 0xc78: // Golden Femur
-		case 0xc79: // Golden Ribcage
-		case 0xc7a: // Golden Skull
-		case 0xc7b: // Golden Candelabra
-		case 0xc7c: // Holy Cross
-		case 0xc7d: // Pearl Necklace
-		case 0xc7e: // Golden Chalice
-		case 0xc7f: // Ruby Gemstone
+		case 'Golden Ankh':
+		case 'Eye of Osiris':
+		case 'Pharaoh\'s Mask':
+		case 'Golden Cockle':
+		case 'Golden Conch':
+		case 'Golden Horn Conch':
+		case 'Golden Nut':
+		case 'Golden Bolt':
+		case 'Golden Femur':
+		case 'Golden Ribcage':
+		case 'Golden Skull':
+		case 'Golden Candelabra':
+		case 'Holy Cross':
+		case 'Pearl Necklace':
+		case 'Golden Chalice':
+		case 'Ruby Gemstone':
 			return 14;
 		default:
-			var itemname = items[id][0];
 			var lastword = itemname.split(" ");
 			var itemtype = lastword[lastword.length - 1];
 			if (itemtype == "Egg") {


### PR DESCRIPTION
Because items change IDs fairly frequently when swaths of items are reassigned positions in the game's XML definitions, or when new items are introduced, sorting them based on their *current* ID is a fairly fragile strategy which is in no way future-proof.

Instead, given that the item names and their associated tiers are known and well-defined, we can instead sort using the item name as the switch case.

This addresses [#80 (comment)](https://github.com/atomizer/muledump/pull/80#issuecomment-142095938).