### PR TITLE
slice off backpack items if char has no backpack

### DIFF
--- a/lib/mule.js
+++ b/lib/mule.js
@@ -435,7 +435,11 @@ Mule.prototype.parse = function(data) {
 
 		// items
 		var eq = (c.Equipment || '').split(',');
-		this.items.chars.push(eq);
+		if (+c.HasBackpack) {
+			this.items.chars.push(eq);
+		} else {
+			this.items.chars.push(eq.slice(0, 12));
+		}
 		var dobp = this.opt('backpack') && +c.HasBackpack
 		if (this.opt('equipment') || this.opt('inv') || dobp) {
 			f = true;


### PR DESCRIPTION
I've noticed that the backpack empty space count is not always correct,
The rotmg server returns this:
	<Char id="***">
		<ObjectType>782</ObjectType>
		<Level>20</Level>
		<Exp>154063</Exp>
		<CurrentFame>261</CurrentFame>
		<Equipment>2719,2774,2656,2755,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1</Equipment>
		... snip ...
		<HasBackpack>0</HasBackpack>
	</Char>
The character has no backpack, yet equipment contains 19 items, these 7 nonexistent empty spaces get counted in totals.

So I slice the array if the char has no backpack before pushing it into items.